### PR TITLE
feat: pass through the name of the event that triggered the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ runs:
     - run: |
         curl -X POST https://api.github.com/repos/${{inputs.organisation-name}}/${{inputs.repository-name-to-trigger}}/dispatches \
         -u ${{ inputs.private-github-token }} \
-        --data '{"event_type": "deployment", "client_payload": ${{ toJSON(github.event) }} }'
+        --data '{"event_type": "${{ github.event_name }}", "client_payload": ${{ toJSON(github.event) }} }'
       shell: bash


### PR DESCRIPTION
Since this action can be used with many triggers, not just the deployment event, this change
modifies the payload used to trigger the remote repository by using the name of the triggering event
instead of always using 'deployment', even when the action was triggered by another event.